### PR TITLE
Move boto3 to a dev dependency

### DIFF
--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (0, 9, 14)
+version_info = (0, 9, 15)
 version = '.'.join(map(str, version_info))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-boto3==1.3.1
 pyyaml==3.11

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,5 +20,6 @@ coverage==4.0.3
 flake8==2.5.4
 boto==2.40.0
 python-memcached==1.57
+boto3
 
 -r requirements.txt


### PR DESCRIPTION
Because lambda provides a version of boto3, we should move the dependency to the dev requirements so that it can be ran locally. Having it hard pinned in the requirements.txt, restricts the ability to use other libraries that do not support that version.