### PR TITLE
Fix log verbosity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 aws-lambda-fsm-workflows
 
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/__init__.py
+++ b/aws_lambda_fsm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/action.py
+++ b/aws_lambda_fsm/action.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/action.py
+++ b/aws_lambda_fsm/action.py
@@ -15,6 +15,7 @@
 # system imports
 from functools import wraps
 import logging
+
 logger = logging.getLogger(__name__)
 
 

--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -55,12 +55,9 @@ class Object(object):
 
 
 _local = Object()
-<<<<<<< HEAD
-_lock = RLock()
 _loglock = RLock()
-=======
 _rlock = RLock()
->>>>>>> master
+
 
 TRACE = 5
 ALREADY_LOGGED = set()

--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -340,7 +340,7 @@ def _get_elasticache_engine_and_connection(cache_arn):
 
         # not found in any of the usual places
         if not engine or not connection:
-            logger.fatal("Cache ARN %s is not valid.", cache_arn)
+            log_once(logger.fatal, "Cache ARN %s is not valid.", cache_arn)
 
         setattr(_local, attr, (engine, connection))
 
@@ -448,7 +448,7 @@ def _get_redis_connection(cache_arn, entry):
                 connection = redis.StrictRedis(host=host, port=port, db=0, ssl=ssl, password=password)
 
             if not connection:
-                logger.fatal("Redis Cache ARN %s is not valid.", cache_arn)
+                log_once(logger.fatal, "Redis Cache ARN %s is not valid.", cache_arn)
 
             setattr(_local, attr, connection)
 
@@ -496,7 +496,7 @@ def _get_memcached_connection(cache_arn, entry):
                 connection = memcache.Client([endpoint_url])  # memcache library does not discover nodes
 
             if not connection:
-                logger.fatal("Memcached Cache ARN %s is not valid.", cache_arn)
+                log_once(logger.fatal, "Memcached Cache ARN %s is not valid.", cache_arn)
 
             setattr(_local, attr, connection)
 

--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -2003,7 +2003,8 @@ def _validate_config(key, data):
         log_once(logger.warning, "SECONDARY_%s_SOURCE is unset (failover not configured).", key)
 
     if failover and secondary and primary == secondary:
-        log_once(logger.warning, "PRIMARY_%s_SOURCE = SECONDARY_%s_SOURCE (failover not configured optimally).", key, key)
+        log_once(logger.warning,
+                 "PRIMARY_%s_SOURCE = SECONDARY_%s_SOURCE (failover not configured optimally).", key, key)
 
 
 def _validate_sqs_urls():
@@ -2060,14 +2061,16 @@ def _validate_elasticache_endpoints():
                 log_once(logger.warning, "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (engine)", cache_arn)
             else:
                 if entry[AWS_ELASTICACHE.Engine] not in AWS_ELASTICACHE.ENGINE.ALL:
-                    log_once(logger.warning, "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (unknown engine)", cache_arn)
+                    log_once(logger.warning,
+                             "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (unknown engine)", cache_arn)
 
             if AWS_ELASTICACHE.ConfigurationEndpoint not in entry:
                 log_once(logger.warning, "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (endpoint)", cache_arn)
             else:
                 endpoint = entry.get(AWS_ELASTICACHE.ConfigurationEndpoint, {})
                 if AWS_ELASTICACHE.CONFIGURATION_ENDPOINT.Address not in endpoint:
-                    log_once(logger.warning, "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (address)", cache_arn)
+                    log_once(logger.warning,
+                             "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (address)", cache_arn)
                 if AWS_ELASTICACHE.CONFIGURATION_ENDPOINT.Port not in endpoint:
                     log_once(logger.warning, "ELASTICACHE_ENDPOINTS has invalid entry for key '%s' (port)", cache_arn)
 

--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -71,7 +71,7 @@ def log_once(method, *args, **kwargs):
     :param args: a list of args for the logger method
     :param kwargs: a dict of kwargs for the logger method
     """
-    key = "%s-%s-%s" % (method.__name__, args, kwargs)
+    key = "%s-%s-%s" % (getattr(method, '__name__', method), args, kwargs)
     with _loglock:
         if key not in ALREADY_LOGGED:
             method(*args, **kwargs)

--- a/aws_lambda_fsm/client.py
+++ b/aws_lambda_fsm/client.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/config.py
+++ b/aws_lambda_fsm/config.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/constants.py
+++ b/aws_lambda_fsm/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/fsm.py
+++ b/aws_lambda_fsm/fsm.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/handler.py
+++ b/aws_lambda_fsm/handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/state.py
+++ b/aws_lambda_fsm/state.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/transition.py
+++ b/aws_lambda_fsm/transition.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws_lambda_fsm/utils.py
+++ b/aws_lambda_fsm/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/CHAOS.md
+++ b/docs/CHAOS.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/IDEMPOTENCY.md
+++ b/docs/IDEMPOTENCY.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/JUSTIFICATION.md
+++ b/docs/JUSTIFICATION.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/STEP.md
+++ b/docs/STEP.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/YAML.md
+++ b/docs/YAML.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/docs/__init__.py
+++ b/examples/docs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/docs/actions.py
+++ b/examples/docs/actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/docs/fsm.yaml
+++ b/examples/docs/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/ecs/FSM.md
+++ b/examples/ecs/FSM.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/ecs/__init__.py
+++ b/examples/ecs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/ecs/actions.py
+++ b/examples/ecs/actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/ecs/fsm.yaml
+++ b/examples/ecs/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/encrypt_s3/FSM.md
+++ b/examples/encrypt_s3/FSM.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/encrypt_s3/__init__.py
+++ b/examples/encrypt_s3/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/encrypt_s3/actions.py
+++ b/examples/encrypt_s3/actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/encrypt_s3/fsm.yaml
+++ b/examples/encrypt_s3/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/fsm.yaml
+++ b/examples/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tracer/FSM.md
+++ b/examples/tracer/FSM.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2017 Workiva Inc.
+Copyright 2016-2018 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/tracer/__init__.py
+++ b/examples/tracer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tracer/actions.py
+++ b/examples/tracer/actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tracer/fsm.yaml
+++ b/examples/tracer/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fsm.yaml
+++ b/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/settings.py.example
+++ b/settings.py.example
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/__init__.py
+++ b/tests/aws_lambda_fsm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_action.py
+++ b/tests/aws_lambda_fsm/test_action.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_aws.py
+++ b/tests/aws_lambda_fsm/test_aws.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_client.py
+++ b/tests/aws_lambda_fsm/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_config.py
+++ b/tests/aws_lambda_fsm/test_config.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_fsm.py
+++ b/tests/aws_lambda_fsm/test_fsm.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_handler.py
+++ b/tests/aws_lambda_fsm/test_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_state.py
+++ b/tests/aws_lambda_fsm/test_state.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/aws_lambda_fsm/test_transition.py
+++ b/tests/aws_lambda_fsm/test_transition.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/settings.py.docker
+++ b/tests/functional/settings.py.docker
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/supervisor.conf
+++ b/tests/functional/supervisor.conf
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/test_base.py
+++ b/tests/functional/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/test_dispatched.py
+++ b/tests/functional/test_dispatched.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/test_lease.py
+++ b/tests/functional/test_lease.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/actions.py
+++ b/tests/integration/actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/fsm.yaml
+++ b/tests/integration/fsm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_tracer.py
+++ b/tests/integration/test_tracer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/build_zip.sh
+++ b/tools/build_zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/create_dynamodb_table.py
+++ b/tools/create_dynamodb_table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/create_kinesis_stream.py
+++ b/tools/create_kinesis_stream.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/create_resources.py
+++ b/tools/create_resources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/create_sns_topic.py
+++ b/tools/create_sns_topic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/create_sqs_queue.py
+++ b/tools/create_sqs_queue.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/dev_ecs.py
+++ b/tools/dev_ecs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/dev_lambda.py
+++ b/tools/dev_lambda.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/fsm_docker_runner.py
+++ b/tools/fsm_docker_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/fsm_sqs_to_arn.py
+++ b/tools/fsm_sqs_to_arn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/start_state_machine.py
+++ b/tools/start_state_machine.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/yaml_to_graphviz.py
+++ b/tools/yaml_to_graphviz.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/yaml_to_json.py
+++ b/tools/yaml_to_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-# Copyright 2016-2017 Workiva Inc.
+# Copyright 2016-2018 Workiva Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
1. There are several warning/error/fatal log messages that only need to be emitted once per AWS Lambda instance, rather than once per AWS Lambda request. This PR wraps the appropriate logging calls in a helper `log_once` that keeps a cache of the messages that have already been logged, and prevent multiple loggings.
2. Updated the Copyright date range as well.

@jasonbritton-wk 