### PR TITLE
fixed _validate_elasticache_endpoints() since it was missed in the last release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ settings.py
 .DS_Store
 *.graffle
 dump.rdb
+build

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,14 @@ test: clean check-config
 	echo ${COVER_PACKAGE}
 	nosetests -a '!functional' --logging-level=ERROR --with-xunit --xunit-file=unit.xml
 
+unit: test
+
 functional: clean check-config
 	echo ${COVER_PACKAGE}
 	nosetests -a 'functional' --logging-level=ERROR --with-xunit --xunit-file=unit.xml
 
 flake8:
 	flake8 --max-line-length=120 --ignore=E000 --exclude=settingslocal.py .
+
+all: test flake8 coverage
 

--- a/aws_lambda_fsm/constants.py
+++ b/aws_lambda_fsm/constants.py
@@ -198,7 +198,6 @@ class AWS_ELASTICACHE(object):
 
         CLUSTER = 'cluster'
         SNAPSHOT = 'snapshot'
-        REPLICATION_GROUP = 'repgroup'
 
     class ENDPOINT(object):
 


### PR DESCRIPTION
`_validate_elasticache_endpoints()` was out of sync