### PR TITLE
WAP-997: Added lambda event to the volatile map

### DIFF
--- a/aws_lambda_fsm/constants.py
+++ b/aws_lambda_fsm/constants.py
@@ -57,6 +57,7 @@ class OBJ(object):
     SOURCE = 'source'
     DELAY = 'delay'
     FENCE_TOKEN = 'fence_token'
+    LAMBDA_RECORD = 'lambda_record'
 
 
 class ERRORS(object):

--- a/aws_lambda_fsm/handler.py
+++ b/aws_lambda_fsm/handler.py
@@ -124,7 +124,7 @@ def lambda_sqs_handler(record):
     """
 
     try:
-        obj = {OBJ.SOURCE: AWS.SQS}
+        obj = {OBJ.SOURCE: AWS.SQS, OBJ.LAMBDA_RECORD: record}
         payload = record[AWS_LAMBDA.SQS_RECORD.BODY]
         _process_payload(payload, obj)
 
@@ -143,7 +143,7 @@ def lambda_kinesis_handler(record):
     """
 
     try:
-        obj = {OBJ.SOURCE: AWS.KINESIS}
+        obj = {OBJ.SOURCE: AWS.KINESIS, OBJ.LAMBDA_RECORD: record}
         encoded = record[AWS_LAMBDA.KINESIS_RECORD.KINESIS][AWS_LAMBDA.KINESIS_RECORD.DATA]
         payload = base64.b64decode(encoded)
         _process_payload(payload, obj)
@@ -163,7 +163,7 @@ def lambda_dynamodb_handler(record):
     """
 
     try:
-        obj = {OBJ.SOURCE: AWS.DYNAMODB_STREAM}
+        obj = {OBJ.SOURCE: AWS.DYNAMODB_STREAM, OBJ.LAMBDA_RECORD: record}
         dynamodb = record[AWS_LAMBDA.DYNAMODB_RECORD.DYNAMODB]
         new_image = dynamodb[AWS_LAMBDA.DYNAMODB_RECORD.NewImage]
         payload = new_image[STREAM_DATA.PAYLOAD][AWS_DYNAMODB.STRING]
@@ -184,7 +184,7 @@ def lambda_sns_handler(record):
     """
 
     try:
-        obj = {OBJ.SOURCE: AWS.SNS}
+        obj = {OBJ.SOURCE: AWS.SNS, OBJ.LAMBDA_RECORD: record}
         sns = record[AWS_LAMBDA.SNS_RECORD.SNS]
         payload = sns[AWS_LAMBDA.SNS_RECORD.Message]
         _process_payload(payload, obj)

--- a/tests/aws_lambda_fsm/test_handler.py
+++ b/tests/aws_lambda_fsm/test_handler.py
@@ -168,7 +168,10 @@ class TestHandler(unittest.TestCase):
     def test_lambda_kinesis_handler(self,
                                     mock_process_payload):
         lambda_kinesis_handler(self.get_kinesis_record())
-        mock_process_payload.assert_called_with('{"machine_name": "barfoo"}', {'source': 'kinesis'})
+        mock_process_payload.assert_called_with(
+            '{"machine_name": "barfoo"}',
+            {'source': 'kinesis', 'lambda_record': self.get_kinesis_record()}
+        )
 
     @mock.patch('aws_lambda_fsm.handler.FSM')
     @mock.patch('aws_lambda_fsm.handler.logger')
@@ -202,7 +205,10 @@ class TestHandler(unittest.TestCase):
     def test_lambda_dynamodb_handler(self,
                                      mock_process_payload):
         lambda_dynamodb_handler(self.get_dynamodb_record())
-        mock_process_payload.assert_called_with('{"pay":"load"}', {'source': 'dynamodb_stream'})
+        mock_process_payload.assert_called_with(
+            '{"pay":"load"}',
+            {'source': 'dynamodb_stream', 'lambda_record': self.get_dynamodb_record()}
+        )
 
     @mock.patch('aws_lambda_fsm.handler.FSM')
     @mock.patch('aws_lambda_fsm.handler.logger')
@@ -259,7 +265,10 @@ class TestHandler(unittest.TestCase):
     def test_lambda_sns_handler(self,
                                 mock_process_payload):
         lambda_sns_handler(self.get_sns_record())
-        mock_process_payload.assert_called_with('{"mess": "age"}', {'source': 'sns'})
+        mock_process_payload.assert_called_with(
+            '{"mess": "age"}',
+            {'source': 'sns', 'lambda_record': self.get_sns_record()}
+        )
 
     @mock.patch('aws_lambda_fsm.handler.FSM')
     @mock.patch('aws_lambda_fsm.handler.logger')
@@ -287,7 +296,10 @@ class TestHandler(unittest.TestCase):
     def test_lambda_sqs_handler(self,
                                 mock_process_payload):
         lambda_sqs_handler(self.get_sqs_record())
-        mock_process_payload.assert_called_with('{"mess": "age"}', {'source': 'sqs'})
+        mock_process_payload.assert_called_with(
+            '{"mess": "age"}',
+            {'source': 'sqs', 'lambda_record': self.get_sqs_record()}
+        )
 
     @mock.patch('aws_lambda_fsm.handler.FSM')
     @mock.patch('aws_lambda_fsm.handler.logger')


### PR DESCRIPTION
1. added AWS Lambda record to the `obj` (volatile) map