### PR TITLE
WAP-2415 Release aws-lambda-fsm-workflows 0.25.0

### DIFF
--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (0, 24, 0)
+version_info = (0, 25, 0)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [WAP-3791: added additional_delay_seconds to impose delay between state transitions, for throttling](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/48)


Requested by: @shawnrusaw-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.24.0...Workiva:release_aws-lambda-fsm-workflows_0.25.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.24.0...0.25.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5495804177678336/logs/)