### PR TITLE
WAP-4774: added support for disabling ssl verification to make working with localstack easier

### DIFF
--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -585,7 +585,9 @@ def _get_service_connection(resource_arn,
                     boto3.client(service,
                                  region_name=region_name,
                                  endpoint_url=endpoint_url,
-                                 config=config)
+                                 config=config,
+                                 **(getattr(settings, 'BOTO3_CLIENT_ADDITIONAL_KWARGS', {}) or {})
+                                 )
 
             # wrapped in a chaos connection if applicable
             if getattr(settings, 'AWS_CHAOS', {}):

--- a/settings.py.example
+++ b/settings.py.example
@@ -55,6 +55,7 @@ ELASTICACHE_PASSWORDS = {}
 
 AWS_CHAOS = {}
 ENDPOINTS = {}
+BOTO3_CLIENT_ADDITIONAL_KWARGS = {}
 
 try:
     import settingslocal

--- a/tests/aws_lambda_fsm/__init__.py
+++ b/tests/aws_lambda_fsm/__init__.py
@@ -62,5 +62,6 @@ class TestSettings(object):
             'testing': 'invalid_endpoint'
         }
     }
+    BOTO3_CLIENT_ADDITIONAL_KWARGS = {}
 
 set_settings(TestSettings)

--- a/tests/aws_lambda_fsm/test_aws.py
+++ b/tests/aws_lambda_fsm/test_aws.py
@@ -643,7 +643,7 @@ class TestAws(unittest.TestCase):
 
     @mock.patch('aws_lambda_fsm.aws.settings')
     @mock.patch('aws_lambda_fsm.aws.boto3')
-    def test_get_service_connection_passes_no_additional_args(self, mock_boto3, mock_settings):
+    def test_get_service_connection_passes_None_additional_args(self, mock_boto3, mock_settings):
         mock_settings.ENDPOINTS = {}
         mock_settings.BOTO3_CLIENT_ADDITIONAL_KWARGS = None
         setattr(_local, 'connection_to_' + _get_test_arn(AWS.KINESIS), None)


### PR DESCRIPTION
1. added ability to inject additional kwargs into the boto3 client function