### PR TITLE
WAP-5316 using sha256 rather than md5 in order to minimize the chances of future fedramp-related-scan warning messages

### DIFF
--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -2009,7 +2009,7 @@ def _start_retries_dynamodb(table_arn, correlation_id, steps, run_at, payload):
     if not dynamodb_conn:
         return  # pragma: no cover
 
-    partition = int(hashlib.md5(correlation_id.encode('utf-8')).hexdigest(), 16) % 16
+    partition = int(hashlib.sha256(correlation_id.encode('utf-8')).hexdigest(), 16) % 16
     table_name = get_arn_from_arn_string(table_arn).slash_resource()
     correlation_id_steps = '%s-%s' % (correlation_id, steps)
     item = {
@@ -2152,7 +2152,7 @@ def _stop_retries_dynamodb(table_arn, correlation_id, steps):
     if not dynamodb_conn:
         return  # pragma: no cover
 
-    partition = int(hashlib.md5(correlation_id.encode('utf-8')).hexdigest(), 16) % 16
+    partition = int(hashlib.sha256(correlation_id.encode('utf-8')).hexdigest(), 16) % 16
     table_name = get_arn_from_arn_string(table_arn).slash_resource()
     correlation_id_steps = '%s-%s' % (correlation_id, steps)
     key = {

--- a/tests/aws_lambda_fsm/test_aws.py
+++ b/tests/aws_lambda_fsm/test_aws.py
@@ -1250,7 +1250,7 @@ class TestAws(unittest.TestCase):
         mock_settings.PRIMARY_RETRY_SOURCE = _get_test_arn(AWS.DYNAMODB)
         start_retries(mock_context, 999, 'd', primary=True)
         mock_get_connection.return_value.put_item.assert_called_with(
-            Item={'partition': {'N': '15'},
+            Item={'partition': {'N': '13'},
                   'payload': {'S': 'd'},
                   'correlation_id_steps': {'S': 'b-z'},
                   'run_at': {'N': '999'}},
@@ -1269,7 +1269,7 @@ class TestAws(unittest.TestCase):
         mock_settings.PRIMARY_STREAM_SOURCE = _get_test_arn(AWS.DYNAMODB)
         start_retries(mock_context, 999, 'd', primary=True, recovering=True)
         mock_get_connection.return_value.put_item.assert_called_with(
-            Item={'partition': {'N': '15'},
+            Item={'partition': {'N': '13'},
                   'payload': {'S': 'd'},
                   'correlation_id_steps': {'S': 'b-z'},
                   'run_at': {'N': '999'}},
@@ -1389,7 +1389,7 @@ class TestAws(unittest.TestCase):
         mock_settings.PRIMARY_RETRY_SOURCE = _get_test_arn(AWS.DYNAMODB)
         stop_retries(mock_context, primary=True)
         mock_get_connection.return_value.delete_item.assert_called_with(
-            Key={'partition': {'N': '15'},
+            Key={'partition': {'N': '13'},
                  'correlation_id_steps': {'S': 'b-z'}},
             TableName='resourcename'
         )


### PR DESCRIPTION
using sha256 rather than md5 in order to minimize the chances of future fedramp-related-scan warning messages

@oliverjensen-wk fyi