### PR TITLE
WAP-5327 Release aws-lambda-fsm-workflows 0.30.0

### DIFF
--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (0, 29, 0)
+version_info = (0, 30, 0)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [WAP-5330 Removing dist folder](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/60)


Requested by: @shawnrusaw-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.29.0...Workiva:release_aws-lambda-fsm-workflows_0.30.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.29.0...0.30.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5495804177678336/logs/)