### PR TITLE
Handle nulls in system context, support lease_timeout in system_context.

### DIFF
--- a/aws_lambda_fsm/aws.py
+++ b/aws_lambda_fsm/aws.py
@@ -985,7 +985,7 @@ def _acquire_lease_memcache(cache_arn, correlation_id, steps, retries, timeout=L
             if timestamp > current_expires:
                 new_fence_token = current_fence_token + 1
                 new_lease_value = _serialize_lease_value(steps, retries, new_expires, new_fence_token)
-                success = memcache_conn.cas(memcache_key, new_lease_value, time=timeout)
+                success = memcache_conn.cas(memcache_key, new_lease_value, time=LEASE_DATA.LEASE_CLEANUP_TIMEOUT)
                 # >>> import memcache
                 # >>> c1=memcache.Client(['localhost:11211'],cache_cas=True)
                 # >>> c2=memcache.Client(['localhost:11211'],cache_cas=True)
@@ -1017,7 +1017,7 @@ def _acquire_lease_memcache(cache_arn, correlation_id, steps, retries, timeout=L
             # if there is no current lease, then get the lease and initialize the fence token
             new_fence_token = 1
             new_lease_value = _serialize_lease_value(steps, retries, new_expires, new_fence_token)
-            success = memcache_conn.add(memcache_key, new_lease_value, time=timeout)
+            success = memcache_conn.add(memcache_key, new_lease_value, time=LEASE_DATA.LEASE_CLEANUP_TIMEOUT)
             # >>> import memcache
             # >>> c1=memcache.Client(['localhost:11211'],cache_cas=True)
             # >>> c2=memcache.Client(['localhost:11211'],cache_cas=True)
@@ -1086,7 +1086,7 @@ def _acquire_lease_redis(cache_arn, correlation_id, steps, retries, timeout=LEAS
                 if timestamp > current_expires:
                     new_fence_token = current_fence_token + 1
                     new_lease_value = _serialize_lease_value(steps, retries, new_expires, new_fence_token)
-                    pipe.setex(redis_key, timeout, new_lease_value)
+                    pipe.setex(redis_key, LEASE_DATA.LEASE_CLEANUP_TIMEOUT, new_lease_value)
 
                 # default fall-through is to re-try to acquire the lease
                 else:
@@ -1098,7 +1098,7 @@ def _acquire_lease_redis(cache_arn, correlation_id, steps, retries, timeout=LEAS
                 # if there is no current lease, then get the lease
                 new_fence_token = 1
                 new_lease_value = _serialize_lease_value(steps, retries, new_expires, new_fence_token)
-                pipe.setex(redis_key, timeout, new_lease_value)
+                pipe.setex(redis_key, LEASE_DATA.LEASE_CLEANUP_TIMEOUT, new_lease_value)
 
             # execute the transaction
             pipe.execute()

--- a/aws_lambda_fsm/constants.py
+++ b/aws_lambda_fsm/constants.py
@@ -52,6 +52,7 @@ class SYSTEM_CONTEXT(object):
     METRICS = 'metrics'
     LEASE_PRIMARY = 'lease_primary'
     ADDITIONAL_DELAY_SECONDS = 'additional_delay_seconds'
+    LEASE_TIMEOUT = 'lease_timeout'
 
 
 class OBJ(object):
@@ -151,7 +152,7 @@ class CACHE_DATA(object):
 
 
 class LEASE_DATA(object):
-    LEASE_TIMEOUT = 5 * 60
+    LEASE_TIMEOUT = 15 * 60 + 5  # aws lambda max time + 5 seconds
     LEASE_CLEANUP_TIMEOUT = 24 * 60 * 60  # daily
     KEY = 'ckey'
     STATE = 'state'

--- a/aws_lambda_fsm/fsm.py
+++ b/aws_lambda_fsm/fsm.py
@@ -288,10 +288,15 @@ class Context(dict):
 
     @property
     def additional_delay_seconds(self):
-        return self.__system_context.get(SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS, 0)
+        return self.__system_context.get(SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS) or 0
 
     @property
     def max_retries(self):
+        # setting max_retries = 0 is valid, so we have to be careful about truthiness here
+        if SYSTEM_CONTEXT.MAX_RETRIES not in self.__system_context:
+            return CONFIG.DEFAULT_MAX_RETRIES
+        elif self.__system_context[SYSTEM_CONTEXT.MAX_RETRIES] is None:
+            return CONFIG.DEFAULT_MAX_RETRIES
         return self.__system_context[SYSTEM_CONTEXT.MAX_RETRIES]
 
     # Mutable properties

--- a/aws_lambda_fsm/fsm.py
+++ b/aws_lambda_fsm/fsm.py
@@ -269,9 +269,23 @@ class Context(dict):
 
         # immutable
         self.__system_context[SYSTEM_CONTEXT.MACHINE_NAME] = \
-            self.__system_context.get(SYSTEM_CONTEXT.MACHINE_NAME, name)  # prefer value in initial_system_context
+            self.__system_context.get(SYSTEM_CONTEXT.MACHINE_NAME) or name  # prefer value in initial_system_context
         self.__system_context[SYSTEM_CONTEXT.MAX_RETRIES] = \
-            self.__system_context.get(SYSTEM_CONTEXT.MAX_RETRIES, max_retries)  # prefer value in initial_system_context
+            self.__system_context.get(SYSTEM_CONTEXT.MAX_RETRIES) or max_retries  # prefer value in initial_system_context
+        self.__system_context[SYSTEM_CONTEXT.CORRELATION_ID] = \
+            self.__system_context.get(SYSTEM_CONTEXT.CORRELATION_ID) or uuid.uuid4().hex
+        self.__system_context[SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS] = \
+            self.__system_context.get(SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS) or 0
+        self.__system_context[SYSTEM_CONTEXT.LEASE_TIMEOUT] = \
+            self.__system_context.get(SYSTEM_CONTEXT.LEASE_TIMEOUT) or LEASE_DATA.LEASE_TIMEOUT
+
+        # mutable
+        self.__system_context[SYSTEM_CONTEXT.STEPS] = \
+            self.__system_context.get(SYSTEM_CONTEXT.STEPS) or 0
+        self.__system_context[SYSTEM_CONTEXT.RETRIES] = \
+            self.__system_context.get(SYSTEM_CONTEXT.RETRIES) or 0
+        self.__system_context[SYSTEM_CONTEXT.LEASE_PRIMARY] = \
+            self.__system_context.get(SYSTEM_CONTEXT.LEASE_PRIMARY) or True
 
         self._errors = {}
 
@@ -283,32 +297,25 @@ class Context(dict):
 
     @property
     def correlation_id(self):
-        if SYSTEM_CONTEXT.CORRELATION_ID not in self.__system_context:
-            self.__system_context[SYSTEM_CONTEXT.CORRELATION_ID] = uuid.uuid4().hex
         return self.__system_context[SYSTEM_CONTEXT.CORRELATION_ID]
 
     @property
     def additional_delay_seconds(self):
-        return self.__system_context.get(SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS) or 0
+        return self.__system_context[SYSTEM_CONTEXT.ADDITIONAL_DELAY_SECONDS]
 
     @property
     def max_retries(self):
-        # setting max_retries = 0 is valid, so we have to be careful about truthiness here
-        if SYSTEM_CONTEXT.MAX_RETRIES not in self.__system_context:
-            return CONFIG.DEFAULT_MAX_RETRIES
-        elif self.__system_context[SYSTEM_CONTEXT.MAX_RETRIES] is None:
-            return CONFIG.DEFAULT_MAX_RETRIES
         return self.__system_context[SYSTEM_CONTEXT.MAX_RETRIES]
 
     @property
     def lease_timout(self):
-        return self.__system_context.get(SYSTEM_CONTEXT.LEASE_TIMEOUT) or LEASE_DATA.LEASE_TIMEOUT
+        return self.__system_context[SYSTEM_CONTEXT.LEASE_TIMEOUT]
 
     # Mutable properties
 
     @property
     def current_event(self):
-        return self.__system_context.get(SYSTEM_CONTEXT.CURRENT_EVENT)
+        return self.__system_context[SYSTEM_CONTEXT.CURRENT_EVENT]
 
     @current_event.setter
     def current_event(self, current_event):
@@ -316,8 +323,6 @@ class Context(dict):
 
     @property
     def steps(self):
-        if SYSTEM_CONTEXT.STEPS not in self.__system_context:
-            self.__system_context[SYSTEM_CONTEXT.STEPS] = 0
         return self.__system_context[SYSTEM_CONTEXT.STEPS]
 
     @steps.setter
@@ -326,8 +331,6 @@ class Context(dict):
 
     @property
     def retries(self):
-        if SYSTEM_CONTEXT.RETRIES not in self.__system_context:
-            self.__system_context[SYSTEM_CONTEXT.RETRIES] = 0
         return self.__system_context[SYSTEM_CONTEXT.RETRIES]
 
     @retries.setter
@@ -341,8 +344,6 @@ class Context(dict):
 
     @property
     def lease_primary(self):
-        if SYSTEM_CONTEXT.LEASE_PRIMARY not in self.__system_context:
-            self.__system_context[SYSTEM_CONTEXT.LEASE_PRIMARY] = True
         return self.__system_context[SYSTEM_CONTEXT.LEASE_PRIMARY]
 
     @lease_primary.setter

--- a/tests/aws_lambda_fsm/test_aws.py
+++ b/tests/aws_lambda_fsm/test_aws.py
@@ -1721,7 +1721,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1, primary=False)
         self.assertTrue(0 is ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1299:1', time=86400)
+        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1904:1', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_secondary_cache_source')
@@ -1740,7 +1740,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1, primary=False)
         self.assertFalse(ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1299:1', time=86400)
+        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1904:1', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_primary_cache_source')
@@ -1759,7 +1759,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1)
         self.assertFalse(ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1299:1', time=86400)
+        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1904:1', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_primary_cache_source')
@@ -1778,7 +1778,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1)
         self.assertTrue(ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1299:1', time=86400)
+        mock_get_connection.return_value.add.assert_called_with('lease-a', '1:1:1904:1', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_primary_cache_source')
@@ -1797,7 +1797,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1)
         self.assertFalse(ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.cas.assert_called_with('lease-a', '1:1:1299:100', time=86400)
+        mock_get_connection.return_value.cas.assert_called_with('lease-a', '1:1:1904:100', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_primary_cache_source')
@@ -1816,7 +1816,7 @@ class LeaseMemcacheTest(unittest.TestCase):
         ret = acquire_lease('a', 1, 1)
         self.assertTrue(ret)
         mock_get_connection.return_value.gets.assert_called_with('lease-a')
-        mock_get_connection.return_value.cas.assert_called_with('lease-a', '1:1:1299:100', time=86400)
+        mock_get_connection.return_value.cas.assert_called_with('lease-a', '1:1:1904:100', time=86400)
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
     @mock.patch('aws_lambda_fsm.aws.get_primary_cache_source')
@@ -1992,7 +1992,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:1')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:1')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2016,7 +2016,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:1')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:1')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2040,7 +2040,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:1')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:1')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2063,7 +2063,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:1')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:1')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2087,7 +2087,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:100')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:100')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2110,7 +2110,7 @@ class LeaseRedisTest(unittest.TestCase):
         mock_pipe.watch.assert_called_with('lease-a')
         mock_pipe.get.assert_called_with('lease-a')
         mock_pipe.multi.assert_called_with()
-        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1299:100')
+        mock_pipe.setex.assert_called_with('lease-a', 86400, '1:1:1904:100')
         mock_pipe.execute.assert_called_with()
 
     @mock.patch('aws_lambda_fsm.aws.get_connection')
@@ -2287,7 +2287,7 @@ class LeaseDynamodbTest(unittest.TestCase):
                                        ':o': {'S': 'open'},
                                        ':z': {'N': '0'},
                                        ':t': {'N': '999'},
-                                       ':e': {'N': '1299'},
+                                       ':e': {'N': '1904'},
                                        ':f': {'N': '1'},
                                        ':r': {'N': '1'},
                                        ':s': {'N': '1'}},
@@ -2318,7 +2318,7 @@ class LeaseDynamodbTest(unittest.TestCase):
                                        ':o': {'S': 'open'},
                                        ':z': {'N': '0'},
                                        ':t': {'N': '999'},
-                                       ':e': {'N': '1299'},
+                                       ':e': {'N': '1904'},
                                        ':f': {'N': '1'},
                                        ':r': {'N': '1'},
                                        ':s': {'N': '1'}},
@@ -2349,7 +2349,7 @@ class LeaseDynamodbTest(unittest.TestCase):
                                        ':o': {'S': 'open'},
                                        ':z': {'N': '0'},
                                        ':t': {'N': '999'},
-                                       ':e': {'N': '1299'},
+                                       ':e': {'N': '1904'},
                                        ':f': {'N': '1'},
                                        ':r': {'N': '1'},
                                        ':s': {'N': '1'}},

--- a/tests/aws_lambda_fsm/test_fsm.py
+++ b/tests/aws_lambda_fsm/test_fsm.py
@@ -507,7 +507,8 @@ class TestDispatchExclusiveLock(TestFsmBase):
             'bobloblaw',
             0,
             0,
-            primary=True
+            primary=True,
+            timeout=905
         )
         mock_release_lease.assert_called_with(
             'bobloblaw',
@@ -542,7 +543,8 @@ class TestDispatchExclusiveLock(TestFsmBase):
             'bobloblaw',
             0,
             0,
-            primary=True
+            primary=True,
+            timeout=905
         )
         mock_release_lease.assert_called_with(
             'bobloblaw',
@@ -582,7 +584,8 @@ class TestDispatchExclusiveLock(TestFsmBase):
             'bobloblaw',
             0,
             0,
-            primary=False
+            primary=False,
+            timeout=905
         )
         mock_release_lease.assert_called_with(
             'bobloblaw',

--- a/tests/aws_lambda_fsm/test_fsm.py
+++ b/tests/aws_lambda_fsm/test_fsm.py
@@ -952,3 +952,21 @@ class TestProperties(TestFsmBase):
         fsm = FSM(config_dict=self.CONFIG_DICT)
         instance = fsm.create_FSM_instance('foo', initial_system_context={'max_retries': 999})
         self.assertEqual(999, instance.max_retries)
+
+    def test_lease_timeout_defaults_to_905(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={})
+        self.assertEqual(905, instance.lease_timout)
+
+    def test_lease_timeout_defaults_to_905_when_None(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={'lease_timeout': None})
+        self.assertEqual(905, instance.lease_timout)
+
+    def test_lease_timeout(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={'lease_timeout': 123})
+        self.assertEqual(123, instance.lease_timout)

--- a/tests/aws_lambda_fsm/test_fsm.py
+++ b/tests/aws_lambda_fsm/test_fsm.py
@@ -28,6 +28,7 @@ from aws_lambda_fsm.fsm import FSM
 from aws_lambda_fsm import config
 from aws_lambda_fsm.fsm import Context
 from aws_lambda_fsm.fsm import json_dumps_additional_kwargs
+from aws_lambda_fsm.constants import CONFIG
 
 
 class TestAction(Action):
@@ -919,8 +920,32 @@ class TestProperties(TestFsmBase):
         instance = fsm.create_FSM_instance('foo', initial_system_context={})
         self.assertEqual(0, instance.additional_delay_seconds)
 
+    def test_additional_delay_seconds_defaults_to_0_when_None(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={'additional_delay_seconds': None})
+        self.assertEqual(0, instance.additional_delay_seconds)
+
     def test_additional_delay_seconds(self):
         config._config = {'some/fsm.yaml': {'machines': []}}
         fsm = FSM(config_dict=self.CONFIG_DICT)
         instance = fsm.create_FSM_instance('foo', initial_system_context={'additional_delay_seconds': 999})
         self.assertEqual(999, instance.additional_delay_seconds)
+
+    def test_max_retries_defaults_to_config(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={})
+        self.assertEqual(CONFIG.DEFAULT_MAX_RETRIES, instance.max_retries)
+
+    def test_max_retries_defaults_to_config_when_None(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={'max_retries': None})
+        self.assertEqual(CONFIG.DEFAULT_MAX_RETRIES, instance.max_retries)
+
+    def test_max_retries_defaults(self):
+        config._config = {'some/fsm.yaml': {'machines': []}}
+        fsm = FSM(config_dict=self.CONFIG_DICT)
+        instance = fsm.create_FSM_instance('foo', initial_system_context={'max_retries': 999})
+        self.assertEqual(999, instance.max_retries)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -26,6 +26,7 @@ from botocore.exceptions import ClientError
 from aws_lambda_fsm.client import start_state_machine
 from aws_lambda_fsm import handler
 from aws_lambda_fsm.constants import AWS as AWS_CONSTANTS
+from aws_lambda_fsm.constants import LEASE_DATA
 from aws_lambda_fsm.serialization import json_dumps_additional_kwargs
 from aws_lambda_fsm.serialization import json_loads_additional_kwargs
 
@@ -154,7 +155,7 @@ class AWSStub(object):
         else:
             return self._get_cache_source(primary).get('%s-%s' % (correlation_id, steps))
 
-    def acquire_lease(self, correlation_id, steps, retries, primary=True):
+    def acquire_lease(self, correlation_id, steps, retries, primary=True, timeout=LEASE_DATA.LEASE_TIMEOUT):
         chaos = {True: self.primary_cache_chaos, False: self.secondary_cache_chaos}[primary]
         if chaos and random.uniform(0.0, 1.0) < chaos:
             return 0


### PR DESCRIPTION
1. Handle null values in system_context
2. Changed default lease timeout to 15 minutes and a bit