### PR TITLE
WAP-9325 Release aws-lambda-fsm-workflows 0.35.0

### DIFF
--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (0, 34, 0)
+version_info = (0, 35, 0)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [WAP-9328 additional tests for local transitions](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/109)
	* [WAP-9455: passing along the lambda context in the volatile data](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/112)


Requested by: @shawnrusaw-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.34.0...Workiva:release_aws-lambda-fsm-workflows_0.35.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.34.0...0.35.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5495804177678336/logs/)