### PR TITLE
SRE-28865 removing vendored versions of requests from botocore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@
 
 pyyaml==5.3.1
 future==0.16
+requests==2.24.0

--- a/tests/functional/settings.py.functional
+++ b/tests/functional/settings.py.functional
@@ -14,8 +14,8 @@
 
 import os
 import logging
+import requests.packages.urllib3 as urllib3
 from botocore.exceptions import ClientError
-import botocore.vendored.requests.packages.urllib3 as urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.getLogger("botocore.vendored.requests.packages.urllib3").setLevel(logging.WARNING)
 


### PR DESCRIPTION
## JIRA Ticket
https://jira.atl.workiva.net/browse/SRE-28865

## Problem / Feature
Amazon is is removing the vendored version of the requests library in botocore.  https://aws.amazon.com/es/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/

## Solution / Approach
Update per linkded blog.

## What To Test

## Reviewers