### PR TITLE
SRE-29508 Replace vendored requests in functional test

### DIFF
--- a/tests/functional/settings.py.functional
+++ b/tests/functional/settings.py.functional
@@ -17,7 +17,7 @@ import logging
 import requests.packages.urllib3 as urllib3
 from botocore.exceptions import ClientError
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-logging.getLogger("botocore.vendored.requests.packages.urllib3").setLevel(logging.WARNING)
+logging.getLogger("requests.packages.urllib3").setLevel(logging.WARNING)
 
 PRIMARY_METRICS_SOURCE = None
 SECONDARY_METRICS_SOURCE = None


### PR DESCRIPTION
## Jira Ticket
[SRE-29508](https://jira.atl.workiva.net/browse/SRE-29508)

## Problem / Feature
AWS is deprecating the botocore vendored `requests` package. More info [here](https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/).

## Solution / Approach
Replace references to the botocore vendored package with references to the `requests` package itself. Most of the work was already done by #134. This PR replaces the remaining reference to the vendored package.