### PR TITLE
WAP-9456 Release aws-lambda-fsm-workflows 0.36.0

### DIFF
--- a/aws_lambda_fsm/_pkg_meta.py
+++ b/aws_lambda_fsm/_pkg_meta.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (0, 35, 0)
+version_info = (0, 36, 0)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [SRE-28865 removing vendored versions of requests from botocore](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/134)
	* [SRE-29508 Replace vendored requests in functional test](https://github.com/Workiva/aws-lambda-fsm-workflows/pull/143)


Requested by: @matthewkeefer-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.35.0...Workiva:release_aws-lambda-fsm-workflows_0.36.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/aws-lambda-fsm-workflows/compare/0.35.0...0.36.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5495804177678336/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5495804177678336/?pull_number=153&repo_name=Workiva%2Faws-lambda-fsm-workflows)